### PR TITLE
show dependency on `{dbplyr}` package explicitly

### DIFF
--- a/chapters/sec1/1-3-data-access.qmd
+++ b/chapters/sec1/1-3-data-access.qmd
@@ -509,6 +509,7 @@ In R, we will replace our data loading with connecting to the database.
 Leaving out all the parts that don't change, it looks like
 
 ``` {.r filename="eda.qmd"}
+library(dbplyr)
 con <- DBI::dbConnect(
   duckdb::duckdb(), 
   dbdir = "my-db.duckdb"


### PR DESCRIPTION
I assign the copyright of this contribution to Alex Gold.

Regarding #223 , loading `{dbplyr}` package explicitly in R code may help readers be aware of dependency and install the package before running the R code.
