### PR TITLE
Chapter 6 lab - a couple of fix 

### DIFF
--- a/chapters/sec1/1-5-deployments.qmd
+++ b/chapters/sec1/1-5-deployments.qmd
@@ -447,7 +447,7 @@ You'll also need to add a workflow to GitHub Actions to install Python
 and the necessary Python packages from the `requirements.txt`.
 
 ``` {.yml filename=".github/workflows/publish.yml"}
-    - name: Install Python and Dependencies
+      - name: Install Python and Dependencies
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/chapters/sec1/1-6-docker.qmd
+++ b/chapters/sec1/1-6-docker.qmd
@@ -361,7 +361,7 @@ import vetiver
 import pins
 
 
-b = pins.board_folder('./model', allow_pickle_read=True)
+b = pins.board_folder('/data/model', allow_pickle_read=True)
 v = VetiverModel.from_pin(b, 'penguin_model', version = '20230422T102952Z-cb1f9')
 
 vetiver_api = vetiver.VetiverAPI(v)
@@ -384,7 +384,7 @@ docker run --rm -d \
   -p 8080:8080 \
   --name penguin-model \
   -v /data/model:/data/model \
-  penguin-model-local
+  penguin-model
 ```
 
 Now you should be able to get your model up in no time.


### PR DESCRIPTION
I assign the copyright of this contribution to Alex Gold.

- In app.py, path of pin store may need to be `/data/model` to be consistent with docker volume mount `-v /data/model:/data/model`
- In a script for docker container run, docker image name needs to be `penguin-model` to be consistent with docker image creation script in the main text `docker build -t penguin-model .`

