### PR TITLE
Fix cheatsheets code samples spacing issues

### DIFF
--- a/chapters/append/cheatsheets.qmd
+++ b/chapters/append/cheatsheets.qmd
@@ -4,49 +4,49 @@
 
 ### Checking library + repository status
 
-+-------------------------+---------------+----------------------+
-| **Step**                | R Command     | Python Command       |
-+-------------------------+---------------+----------------------+
-| Check whether library   | `re           | None                 |
-| is in sync with         | nv::status()` |                      |
-| lockfile.               |               |                      |
-+-------------------------+---------------+----------------------+
++-------------------------+------------------+----------------------+
+| **Step**                | R Command.       | Python Command       |
++-------------------------+------------------+----------------------+
+| Check whether library   | `renv::status()` | None                 |
+| is in sync with         |                  |                      |
+| lockfile.               |                  |                      |
++-------------------------+------------------+----------------------+
 
 ### Creating and using a standalone project library
 
 Make sure you're in a standalone project library.
 
-+------------------+--------------------+----------------------+
-| **Step**         | R Command          | Python Command       |
-+------------------+--------------------+----------------------+
-| Create a         | `renv::init()`     | `p                   |
-| standalone       |                    | ython -m venv <dir>` |
-| library.         | Tip: get `{renv}`  |                      |
-|                  | w/                 | Convention: use      |
-|                  | `install           | `.venv` for `<dir>`  |
-|                  | .packages("renv")` |                      |
-|                  |                    | Tip: `{venv}`        |
-|                  |                    | included w/ Python   |
-|                  |                    | 3.5+                 |
-+------------------+--------------------+----------------------+
-| Activate project | `                  | `source              |
-| library.         | renv ::activate()` | <dir> /bin/activate` |
-|                  |                    |                      |
-|                  | Happens            |                      |
-|                  | automatically if   |                      |
-|                  | in RStudio         |                      |
-|                  | project.           |                      |
-+------------------+--------------------+----------------------+
-| Install packages | `install.          | `python -            |
-| as normal.       | packages("<pkg>")` | m pip install <pkg>` |
-+------------------+--------------------+----------------------+
-| Snapshot package | `renv::snapshot()` | `pip freeze          |
-| state.           |                    |  > requirements.txt` |
-+------------------+--------------------+----------------------+
-| Exit project     | Leave R project or | `deactivate`         |
-| environment.     | `r                 |                      |
-|                  | env::deactivate()` |                      |
-+------------------+--------------------+----------------------+
++------------------+----------------------------+----------------------+
+| **Step**         | R Command                  | Python Command       |
++------------------+----------------------------+----------------------+
+| Create a         | `renv::init()`             | `python              |
+| standalone       |                            | -m venv <dir>`       |
+| library.         | Tip: get `{renv}`          |                      |
+|                  | w/                         | Convention: use      |
+|                  | `install.packages("renv")` | `.venv` for `<dir>`  |
+|                  |                            |                      |
+|                  |                            | Tip: `{venv}`        |
+|                  |                            | included w/ Python   |
+|                  |                            | 3.5+                 |
++------------------+----------------------------+----------------------+
+| Activate project | `                          | `source              |
+| library.         | renv::activate()`          | <dir> /bin/activate` |
+|                  |                            |                      |
+|                  | Happens                    |                      |
+|                  | automatically if           |                      |
+|                  | in RStudio                 |                      |
+|                  | project.                   |                      |
++------------------+----------------------------+----------------------+
+| Install packages | `                          | `python -m           |
+| as normal.       | install.packages("<pkg>")` | pip install <pkg>`   |
++------------------+----------------------------+----------------------+
+| Snapshot package | `renv::snapshot()`         | `pip freeze          |
+| state.           |                            |  > requirements.txt` |
++------------------+----------------------------+----------------------+
+| Exit project     | Leave R project or         | `deactivate`         |
+| environment.     | `renv::deactivate()`       |                      |
+|                  |                            |                      |
++------------------+----------------------------+----------------------+
 
 ### Collaborating on someone else's project
 
@@ -60,8 +60,8 @@ Start by downloading the project into a directory on your machine.
 | directory.  | Or open project in       |                      |
 |             | RStudio.                 |                      |
 +-------------+--------------------------+----------------------+
-| Create      | `renv::init()`           | `p                   |
-| project     |                          | ython -m venv <dir>` |
+| Create      | `renv::init()`           | `python              |
+| project     |                          | -m venv <dir>`       |
 | e           |                          |                      |
 | nvironment. |                          | Recommend: use       |
 |             |                          | `.venv` for `<dir>`  |
@@ -126,73 +126,73 @@ Here's are some of those used most frequently.
 | `                    | Commit staging area.                   |
 | commit -m <message>` |                                        |
 +----------------------+----------------------------------------+
-| `p                   | Push to a remote.                      |
-| ush origin <branch>` |                                        |
+| `push                | Push to a remote.                      |
+| origin <branch>`     |                                        |
 +----------------------+----------------------------------------+
-| `p                   | Pull from a remote.                    |
-| ull origin <branch>` |                                        |
+| `pull                | Pull from a remote.                    |
+| origin <branch>`     |                                        |
 +----------------------+----------------------------------------+
-| `che                 | Checkout a branch.                     |
-| ckout <branch name>` |                                        |
+| `checkout            | Checkout a branch.                     |
+| <branch name>`       |                                        |
 +----------------------+----------------------------------------+
-| `check o             | Create and checkout a branch.          |
-| ut -b <branch name>` |                                        |
+| `checkout            | Create and checkout a branch.          |
+| -b <branch name>`    |                                        |
 +----------------------+----------------------------------------+
-| `bran                | Delete a branch.                       |
-| ch -d <branch name>` |                                        |
+| `branch              | Delete a branch.                       |
+| -d <branch name>`    |                                        |
 +----------------------+----------------------------------------+
 
 ## Docker {#cheat-docker}
 
 ### Docker CLI commands
 
-+------------+------------+------------+---------------------+
-| **Stage**  | **Command  | **What it  | **Notes and helpful |
-|            | (prefix w/ | does**     | options**           |
-|            | `          |            |                     |
-|            | docker`)** |            |                     |
-+------------+------------+------------+---------------------+
-| Build      | `build <d  | Builds a   | `-t <name:tag>`     |
-|            | irectory>` | directory  | provides a name to  |
-|            |            | into an    | the container.      |
-|            |            | image.     |                     |
-|            |            |            | `tag` is optional,  |
-|            |            |            | defaults to         |
-|            |            |            | `latest`.           |
-+------------+------------+------------+---------------------+
-| Move       | `pus       | Push a     |                     |
-|            | h <image>` | container  |                     |
-|            |            | to a       |                     |
-|            |            | registry.  |                     |
-+------------+------------+------------+---------------------+
-| Move       | `pul       | Pull a     | Rarely needed       |
-|            | l <image>` | container  | because `run` pulls |
-|            |            | from a     | the container if    |
-|            |            | registry.  | needed.             |
-+------------+------------+------------+---------------------+
-| Run        | `ru        | Run a      | See flags in next   |
-|            | n <image>` | container. | table.              |
-+------------+------------+------------+---------------------+
-| Run        | `stop <c   | Stop a     | `docker kill` can   |
-|            | ontainer>` | running    | be used if `stop`   |
-|            |            | container. | fails.              |
-+------------+------------+------------+---------------------+
-| Run        | `ps`       | List       | Useful to get       |
-|            |            | running    | container `id` to   |
-|            |            | c          | do things to it.    |
-|            |            | ontainers. |                     |
-+------------+------------+------------+---------------------+
-| Run        | `exec <c   | Run a      | Basically always    |
-|            | ontainer>  | command    | used to open a      |
-|            | <command>` | inside a   | shell with          |
-|            |            | running    | `                   |
-|            |            | container. | docker exec -it <co |
-|            |            |            | ntainer> /bin/bash` |
-+------------+------------+------------+---------------------+
-| Run        | `logs <c   | Views logs |                     |
-|            | ontainer>` | for a      |                     |
-|            |            | container. |                     |
-+------------+------------+------------+---------------------+
++------------+--------------+------------+---------------------+
+| **Stage**  | **Command    | **What it  | **Notes and helpful |
+|            | (prefix w/   | does**     | options**           |
+|            | `            |            |                     |
+|            | docker`)**   |            |                     |
++------------+--------------+------------+---------------------+
+| Build      | `build       | Builds a   | `-t <name:tag>`     |
+|            | <directory>` | directory  | provides a name to  |
+|            |              | into an    | the container.      |
+|            |              | image.     |                     |
+|            |              |            | `tag` is optional,  |
+|            |              |            | defaults to         |
+|            |              |            | `latest`.           |
++------------+--------------+------------+---------------------+
+| Move       | `push        | Push a     |                     |
+|            | <image>`     | container  |                     |
+|            |              | to a       |                     |
+|            |              | registry.  |                     |
++------------+--------------+------------+---------------------+
+| Move       | `pull        | Pull a     | Rarely needed       |
+|            | <image>`     | container  | because `run` pulls |
+|            |              | from a     | the container if    |
+|            |              | registry.  | needed.             |
++------------+--------------+------------+---------------------+
+| Run        | `run         | Run a      | See flags in next   |
+|            | <image>`     | container. | table.              |
++------------+--------------+------------+---------------------+
+| Run        | `stop        | Stop a     | `docker kill` can   |
+|            | <container>` | running    | be used if `stop`   |
+|            |              | container. | fails.              |
++------------+--------------+------------+---------------------+
+| Run        | `ps`         | List       | Useful to get       |
+|            |              | running    | container `id` to   |
+|            |              | c          | do things to it.    |
+|            |              | ontainers. |                     |
++------------+--------------+------------+---------------------+
+| Run        | `exec        | Run a      | Basically always    |
+|            | <container>  | command    | used to open a      |
+|            | <command>`   | inside a   | shell with          |
+|            |              | running    | `docker exec -it    |
+|            |              | container. | <container>         |
+|            |              |            | /bin/bash`          |
++------------+--------------+------------+---------------------+
+| Run        | `logs        | Views logs |                     |
+|            | <container>` | for a      |                     |
+|            |              | container. |                     |
++------------+--------------+------------+---------------------+
 
 ### Flags for `docker run`
 
@@ -213,8 +213,8 @@ Here's are some of those used most frequently.
 |                  | (don't block the | in production.       |
 |                  | terminal).       |                      |
 +------------------+------------------+----------------------+
-| `-               | Publish port     | Needed if you want   |
-| p <port>:<port>` | from inside      | to access an app or  |
+| `-p              | Publish port     | Needed if you want   |
+| <port>:<port>`   | from inside      | to access an app or  |
 |                  | running          | API inside the       |
 |                  | container to     | container.           |
 |                  | outside.         |                      |
@@ -233,8 +233,8 @@ These are the commands that go in a Dockerfile when you're building it.
 +-----------------+--------------------+------------------------+
 | Command         | Purpose            | Example                |
 +-----------------+--------------------+------------------------+
-| `FROM`          | Indicate base      | `F R                   |
-|                 | container.         | OM rocker/r-ver:4.1.0` |
+| `FROM`          | Indicate base      | `FROM                  |
+|                 | container.         | rocker/r-ver:4.1.0`    |
 +-----------------+--------------------+------------------------+
 | `RUN`           | Run a command when | `RUN apt-get update`   |
 |                 | building.          |                        |
@@ -378,15 +378,15 @@ These are the commands that go in a Dockerfile when you're building it.
 |               |                | permanent!**                  |
 +---------------+----------------+-------------------------------+
 | `cp           | Copy.          |                               |
-|  <from> <to>` |                |                               |
+| <from> <to>`  |                |                               |
 +---------------+----------------+-------------------------------+
 | `mv           | Move.          |                               |
-|  <from> <to>` |                |                               |
+| <from> <to>`  |                |                               |
 +---------------+----------------+-------------------------------+
 | `*`           | Wildcard.      |                               |
 +---------------+----------------+-------------------------------+
-| `m            | Make/remove    | `-p` - create any parts of    |
-| kdir`/`rmdir` | directory.     | path that dont exist          |
+| `mkdir`       | Make/remove    | `-p` - create any parts of    |
+| /`rmdir`      | directory.     | path that dont exist          |
 +---------------+----------------+-------------------------------+
 
 ### Move things to/from server
@@ -478,8 +478,8 @@ ssh <user>@<host>
 | **Command**   | **What it does**         | **Helpful         |
 |               |                          | options + notes** |
 +---------------+--------------------------+-------------------+
-| `s            | Change to be a different |                   |
-| u <username>` | user.                    |                   |
+| `su           | Change to be a different |                   |
+| <username>`   | user.                    |                   |
 +---------------+--------------------------+-------------------+
 | `whoami`      | Get username of current  |                   |
 |               | user.                    |                   |
@@ -491,8 +491,8 @@ ssh <user>@<host>
 +---------------+--------------------------+-------------------+
 | `useradd`     | Add a new user.          |                   |
 +---------------+--------------------------+-------------------+
-| `usermo       | Modify user `username`.  | `-aG <group>`     |
-| d <username>` |                          | adds to a group   |
+| `usermod      | Modify user `username`.  | `-aG <group>`     |
+| <username>`   |                          | adds to a group   |
 |               |                          | (e.g.,`sudo`)     |
 +---------------+--------------------------+-------------------+
 
@@ -502,9 +502,9 @@ ssh <user>@<host>
 | Command            | What it does      | Helpful options +   |
 |                    |                   | notes               |
 +====================+===================+=====================+
-| `chmod <pe         | Modifies          | Number indicates    |
-| rmissions> <file>` | permissions on a  | permissions for     |
-|                    | file or           | user, group,        |
+| `chmod             | Modifies          | Number indicates    |
+| <permissions>      | permissions on a  | permissions for     |
+| <file>`            | file or           | user, group,        |
 |                    | directory.        | others: add `4` for |
 |                    |                   | read, `2` for       |
 |                    |                   | write, `1` for      |
@@ -512,9 +512,9 @@ ssh <user>@<host>
 |                    |                   | nothing,            |
 |                    |                   | e.g.,`644`.         |
 +--------------------+-------------------+---------------------+
-| `chown <u          | Change the owner  | Can be used for     |
-| ser/group> <file>` | of a file or      | user or group,      |
-|                    | directory.        | e.g.,`:my-group`.   |
+| `chown             | Change the owner  | Can be used for     |
+| <user>:<group>     | of a file or      | user or group,      |
+| <file>`            | directory.        | e.g.,`:my-group`.   |
 +--------------------+-------------------+---------------------+
 | `sudo <command>`   | Adopt root        |                     |
 |                    | permissions for   |                     |
@@ -527,8 +527,8 @@ ssh <user>@<host>
 +----------------------------+-----------------------------------+
 | **Command**                | **What it does**                  |
 +----------------------------+-----------------------------------+
-| `apt -get upd              | Fetch and install upgrades to     |
-| ate && apt-get upgrade -y` | system packages                   |
+| `apt-get update            | Fetch and install upgrades to     |
+| && apt-get upgrade -y`.    | system packages                   |
 +----------------------------+-----------------------------------+
 | `                          | Install a system package.         |
 | apt-get install <package>` |                                   |
@@ -572,34 +572,34 @@ ssh <user>@<host>
 
 ### Networking
 
-+---------------+----------------------+-----------------------+
-| **Command**   | **What it does**     | **Helpful Options**   |
-+---------------+----------------------+-----------------------+
-| `netstat`     | See ports and        | Usually used with     |
-|               | services using them. | `-tlp`, for tcp       |
-|               |                      | listening             |
-|               |                      | applications,         |
-|               |                      | including `pid`.      |
-+---------------+----------------------+-----------------------+
-| `ssh -L       | Port forwards a      | Remote `ip` is        |
-| <port>:<ip>:< | remote port on       | usually `localhost`.  |
-| port>:<host>` | remote host to       |                       |
-|               | local.               | Choose local port to  |
-|               |                      | match remote port.    |
-+---------------+----------------------+-----------------------+
++----------------------------+----------------------+-----------------------+
+| **Command**                | **What it does**     | **Helpful Options**   |
++----------------------------+----------------------+-----------------------+
+| `netstat`                  | See ports and        | Usually used with     |
+|                            | services using them. | `-tlp`, for tcp       |
+|                            |                      | listening             |
+|                            |                      | applications,         |
+|                            |                      | including `pid`.      |
++----------------------------+----------------------+-----------------------+
+| `ssh -L                    | Port forwards a      | Remote `ip` is        |
+| <port>:<ip>:<port>:<host>` | remote port on       | usually `localhost`.  |
+|                            | remote host to       |                       |
+|                            | local.               | Choose local port to  |
+|                            |                      | match remote port.    |
++----------------------------+----------------------+-----------------------+
 
 ### The path
 
-+------------------+---------------------------------------------+
-| **Command**      | **What it does**                            |
-+------------------+---------------------------------------------+
-| `                | Finds the location of the binary that runs  |
-| which <command>` | when you run `command`.                     |
-+------------------+---------------------------------------------+
-| `ln -s <linked l | Creates a symlink from file/directory at    |
-| ocation>:<where  | `linked location` to                        |
-| to put symlink>` | `where to put symlink`.                     |
-+------------------+---------------------------------------------+
++-------------------------+---------------------------------------------+
+| **Command**             | **What it does**                            |
++-------------------------+---------------------------------------------+
+| `                       | Finds the location of the binary that runs  |
+| which <command>`        | when you run `command`.                     |
++-------------------------+---------------------------------------------+
+| `ln -s                  | Creates a symlink from file/directory at    |
+| <linked location>       | `linked location` to                        |
+| <where to put symlink>` | `where to put symlink`.                     |
++-------------------------+---------------------------------------------+
 
 ### `systemd`
 


### PR DESCRIPTION
T.he [current cheatsheets page](https://do4ds.com/chapters/append/cheatsheets.html) has some spacing issues in the code samples, making some of them show broken functions. This PR aims to fix them.

## current page

![image](https://github.com/akgold/do4ds/assets/7762865/0c12a1a1-5bc0-4e50-8298-ded0977d5364)

## fixed page

![image](https://github.com/akgold/do4ds/assets/7762865/9755eb08-24fa-4318-b07d-eb7da95f93ce)

