### PR TITLE
Fix part and mainmatter

### DIFF
--- a/chapters/intro.qmd
+++ b/chapters/intro.qmd
@@ -338,3 +338,5 @@ $\text{equation font}$.
 
 Variables you would replace with your values will appear in `code font`
 inside angled brackets, like `<your-variable>`.
+
+\mainmatter

--- a/chapters/sec1/1-0-sec-intro.qmd
+++ b/chapters/sec1/1-0-sec-intro.qmd
@@ -1,5 +1,3 @@
-\mainmatter
-
 # DevOps Lessons for Data Science {#sec-1-intro}
 
 You are a software developer.


### PR DESCRIPTION
`\part{}` is not correctly inserted right now. This is because quarto will extract the header of the part file and insert `\part{}` before any content.

Putting `\mainmatter` at the end of the last .qmd before part file insure `\part{}` will be after