### PR TITLE
No numbering and title on code listing 

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -81,9 +81,14 @@ format:
        \usepackage{newpxtext}
        \makeindex
        \usepackage[draft]{hyperref}
-
+    crossref: 
+      lst-title: ""
     include-before-body:
       text: |
+        \makeatletter
+        \renewcommand{\thecodelisting}{}
+        \@addtoreset{codelisting}{chapter}
+        \makeatother
         \frontmatter
     include-after-body:
        text: |


### PR DESCRIPTION
I think you can tweak like this 
It gets me 
![image](https://github.com/akgold/do4ds/assets/6791940/b13d4f69-0715-4753-bfb9-a0235fce5ffc)

But I don't think you could remove the indent (spacing) in from of the file name without doing much more redefinition of a float environment. 

Basically here, the latex code is just renewing a command to remove a counter. 

And title is set to nothing through the option we have in our cross reference system. 