### PR TITLE
Indexing entry correction - Update 1-2-proj-arch.qmd

### DIFF
--- a/chapters/sec1/1-2-proj-arch.qmd
+++ b/chapters/sec1/1-2-proj-arch.qmd
@@ -369,7 +369,7 @@ Microsoft365 sites, and \index{Posit}Posit Connect.
 
 ### Google Sheets
 
-If you're still early in your project lifecycle, a \index{Google Sheets}
+If you're still early in your project lifecycle, a \index{Google Sheets}Google Sheet 
 can be a great way to save and recall a flat file. I wouldn't recommend
 a Google Sheet as a permanent home for data, but it can be a good
 intermediate step while you're still figuring out the right solution for


### PR DESCRIPTION
Suggesting a correction of an index entry for the term "Google Sheets" in the output of a Quarto document - currently the Google Sheet name does not generate resulting in a following sentence:

"If you’re still early in your project lifecycle, a can be a great way to save and recall a flat file. "

correction:

"If you’re still early in your project lifecycle, a "Google Sheet" can be a great way to save and recall a flat file. "